### PR TITLE
Development

### DIFF
--- a/ED-ESI plot.py
+++ b/ED-ESI plot.py
@@ -235,7 +235,7 @@ else:
     fn = msmsfns[0]
 
 # pull time list, each spectrum at those time points, the scan range, and the mz range
-msms = mzml.retrieve_scans(fn=fn)  # retrieve scans
+msms = mzml.retrieve_scans(function=fn)  # retrieve scans
 celist = mzml.functions[fn]['ce']  # collision energy list for the scans that were pulled
 limits = mzml.functions[fn]['window']  # m/z window
 zvals = []  # intensity matrix

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -966,13 +966,13 @@ class mzML(object):
 
     def scan_index(self, scan=None, function=1, bias='lesser'):
         """
-        determines the index for a scan or timepoint in a given function
-        scan: integer or float
-            the scan number or time point to find
-        fn: integer
-            the function to look in
-        bias: options dictated by locate_in_list()
-            bias of index finding
+        Determines the index for a scan or timepoint in a given function
+
+        :param int, float scan: The scan number (int) or time point (float) to find.
+        :param int function: The mzml function to look in
+        :param str bias: Bias of index finding (options dictacted by locate_in_list() )
+        :return: scan index
+        :rtype: int
         """
         if function not in self.functions:
             raise KeyError('The function %d is not in this mzML file.' % function)

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -609,7 +609,7 @@ class mzML(object):
                 level = dct['level']
 
         if affin is None and level is None:
-            return 1  # assume first function
+            return min(self.functions.keys())  # assume first function
 
         elif affin == 'UV':  # if UV-Vis affinity
             for fn in self.functions:  # determine which function is UV-Vis

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -638,7 +638,7 @@ class mzML(object):
         else:  # if some other affinity
             raise ValueError('The specified affinity "%s" is not supported.' % affin)
 
-    def auto_resolution(self, n=10, fn=1, npeaks=4):
+    def auto_resolution(self, n=10, function=1, npeaks=4):
         """
         Attempts to automatically determine the resolution of the spectrometer
         that the provided mzML data file was recorded on.
@@ -700,18 +700,18 @@ class mzML(object):
                     out.append(sci.where(section == maxy)[0][0] + split * ind)
             return out
 
-        if self.functions[fn]['type'] != 'MS':
+        if self.functions[function]['type'] != 'MS':
             raise ValueError(
                 'The auto_resolution function only operates on mass spectrum functions. '
-                'Type of specified function %d: %s' % (fn, self.functions[fn]['type']))
+                'Type of specified function %d: %s' % (function, self.functions[function]['type']))
         ranges = []  # list of scan intervals
 
-        if self.functions[fn]['nscans'] <= 20:  # if the number of scans is less than 20
-            ranges = [[1, self.functions[fn]['nscans']]]
+        if self.functions[function]['nscans'] <= 20:  # if the number of scans is less than 20
+            ranges = [[1, self.functions[function]['nscans']]]
         else:
             while len(ranges) < n:  # generate 10 pseudo-random intervals to sample
-                ran = int(random() * self.functions[fn]['nscans']) + self.functions[fn]['sr'][0]
-                if ran - 10 >= self.functions[fn]['sr'][0] and ran + 10 <= self.functions[fn]['sr'][1]:
+                ran = int(random() * self.functions[function]['nscans']) + self.functions[function]['sr'][0]
+                if ran - 10 >= self.functions[function]['sr'][0] and ran + 10 <= self.functions[function]['sr'][1]:
                     ranges.append([ran - 10, ran + 10])
         if self.verbose is True:
             prog = Progress(string='Estimating resolution of the instrument', fraction=False, last=n)
@@ -719,7 +719,7 @@ class mzML(object):
         for ind, rng in enumerate(ranges):
             if self.verbose is True:
                 prog.write(ind + 1)
-            summed.append(self.sum_scans(rng[0], rng[1], fn, 2, True))  # sum those scans and append output
+            summed.append(self.sum_scans(rng[0], rng[1], function, 2, True))  # sum those scans and append output
         res = []
         for spec in summed:  # calculate resolution for each scan range
             inds = findsomepeaks(spec[1])  # find some peaks

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -638,7 +638,7 @@ class mzML(object):
         else:  # if some other affinity
             raise ValueError('The specified affinity "%s" is not supported.' % affin)
 
-    def auto_resolution(self, n=10, function=1, npeaks=4):
+    def auto_resolution(self, n=10, function=None, npeaks=4):
         """
         Attempts to automatically determine the resolution of the spectrometer
         that the provided mzML data file was recorded on.
@@ -670,6 +670,8 @@ class mzML(object):
                     out.append(sci.where(section == maxy)[0][0] + split * ind)
             return out
 
+        if function is None:  # if no function is provided, use first
+            function = self.associate_to_function()
         if self.functions[function]['type'] != 'MS':
             raise ValueError(
                 'The auto_resolution function only operates on mass spectrum functions. '

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -750,21 +750,21 @@ class mzML(object):
         """
         if self.verbose is True:
             prog = Progress(string='Extracting timepoints and total ion current values from mzML', fraction=False)
-        for func in self.functions:  # add timepoint and tic lists
-            self.functions[func]['timepoints'] = []  # list for timepoints
-            self.functions[func]['tic'] = []  # list for total ion current values
-            if 'level' in self.functions[func] and self.functions[func]['level'] > 1:
-                self.functions[func]['ce'] = []  # list for collision energies
+        for function in self.functions:  # add timepoint and tic lists
+            self.functions[function]['timepoints'] = []  # list for timepoints
+            self.functions[function]['tic'] = []  # list for total ion current values
+            if 'level' in self.functions[function] and self.functions[function]['level'] > 1:
+                self.functions[function]['ce'] = []  # list for collision energies
         for spectrum in self.tree.getElementsByTagName('spectrum'):
             attr = branch_attributes(spectrum)
-            func, proc, scan = fps(spectrum)  # determine function, process, and scan numbers
+            function, proc, scan = fps(spectrum)  # determine function, process, and scan numbers
             if self.verbose is True:
                 prog.write(attr['index'] + 1)
             p = branch_cvparams(spectrum)  # pull spectrum's cvparameters
-            self.functions[func]['timepoints'].append(p['MS:1000016'].value)  # start scan time
-            self.functions[func]['tic'].append(p['MS:1000285'].value)  # total ion current
+            self.functions[function]['timepoints'].append(p['MS:1000016'].value)  # start scan time
+            self.functions[function]['tic'].append(p['MS:1000285'].value)  # total ion current
             if 'MS:1000045' in p:
-                self.functions[func]['ce'].append(p['MS:1000045'].value)  # collision energy
+                self.functions[function]['ce'].append(p['MS:1000045'].value)  # collision energy
         self.ftt = True
         if self.verbose is True:
             prog.fin()

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -1027,7 +1027,7 @@ class mzML(object):
     def sum_scans(self,
                   start=None,
                   end=None,
-                  fn=None,
+                  function=None,
                   dec=3,
                   mute=False
                   ):
@@ -1038,26 +1038,26 @@ class mzML(object):
         :param float, int start: start point to begin summing. ``int`` is interpreted as a scan number, ``float`` is
             interpreted as a time point in the acquisition.
         :param float, int end: end point to finish summing. Parameters are the same as with start.
-        :param int fn: mzML function to sum. If this is not provided, the first function will be used.
+        :param int function: mzML function to sum. If this is not provided, the first function will be used.
         :param int dec: number of decimal places to track in the spectrum (lower values lower memory overhead).
         :param bool mute: override chatty mode of mzML object
         :return: summed spectrum in the format ``[[m/z values], [intensity values]]``
         :rtype: list
         """
         # if no function is specified, use the first function
-        if fn is None:
-            fn = min(self.functions.keys())
-        elif fn not in self.functions:  # if fn is not defined
-            raise KeyError(f'The function {fn} is not defined in the mzML object. Available options: '
+        if function is None:
+            function = min(self.functions.keys())
+        elif function not in self.functions:  # if fn is not defined
+            raise KeyError(f'The function {function} is not defined in the mzML object. Available options: '
                            f'{", ".join([str(key) for key in self.functions.keys()])}')
-        if self.functions[fn]['type'] != 'MS':
+        if self.functions[function]['type'] != 'MS':
             raise ValueError(f'The sum_scans function does not have the functionality to sum non-mass spec scans.'
-                             f'The specified function {fn} is of type {self.functions[fn]["type"]}')
-        start = self.scan_index(start, fn, 'greater')
-        end = self.scan_index(end, fn, 'lesser')
+                             f'The specified function {function} is of type {self.functions[function]["type"]}')
+        start = self.scan_index(start, function, 'greater')
+        end = self.scan_index(end, function, 'lesser')
 
-        spec = Spectrum(dec, start=self.functions[fn]['window'][0],
-                        end=self.functions[fn]['window'][1])  # create Spectrum object
+        spec = Spectrum(dec, start=self.functions[function]['window'][0],
+                        end=self.functions[function]['window'][1])  # create Spectrum object
 
         if self.verbose is True and mute is False:
             prog = Progress(string='Combining spectrum', fraction=False, first=start, last=end)

--- a/pythoms/mzml.py
+++ b/pythoms/mzml.py
@@ -646,43 +646,13 @@ class mzML(object):
         calculate the resolution of each of those samples and return the
         average resolution.
 
-        **Parameters**
-
-        n: *integer*
-            The number of psuedo-random samples of the spectrum to determine
+        :param int n: The number of psuedo-random samples of the spectrum to determine
             the resolution of. Default 10.
-
-        fn: *integer*
-            The mzML function number to calculate the resolution of. Default 1.
-
-
-        **Returns**
-
-        return item: *type*
-            description
-
-
-        **Examples**
-
-        ::
-
-            code line 1
-            code line 2
-
-
-        **Method**
-
-        This function uses the following method to estimate the resolution:
-        * find n pseudo-random samples using a random number generator
-        *
-
+        :param int function: The mzML function number to calculate the resolution of. Default 1.
+        :param int npeaks: number of peaks to to try to find
+        :return: Estimated resolution of the spectrum
+        :rtype: float
         """
-        """
-        automatically determines the resolution of the spectrometer that recorded the mzml file
-        resolution is based on the average resolution of 10 pseudo-random samples
-        each sample spectrum is split into 4 sections and 4 peaks are found to calculate the resolution
-        """
-
         def findsomepeaks(y):
             """roughly locates 4 peaks by maximum values in the spectrum and returns their index"""
             split = int(len(y) / npeaks)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 NAME = 'pythoms'
-VERSION = '1.0.4.4'
+VERSION = '1.0.4.5'
 AUTHOR = 'Lars Yunker'
 
 PACKAGES = find_packages()

--- a/spectrum binner.py
+++ b/spectrum binner.py
@@ -41,7 +41,10 @@ def bin_spectra(filename, start=None, end=None, save=True, dec=3, function=None)
         if type(save) == str:  # if a filename was provided for the Excel file
             xlfile = XLSX(save, create=True)
         else:  # otherwise use the mzML filename
-            xlfile = XLSX(filename, create=True)
+            xlfile = XLSX(
+                f'{filename}.xlsx',
+                create=True
+            )
         xlfile.writespectrum(  # write the spectrum to file
             x,
             y,

--- a/spectrum binner.py
+++ b/spectrum binner.py
@@ -9,7 +9,7 @@ from pythoms.xlsx import XLSX
 from pythoms.scripttime import ScriptTime
 
 
-def bin_spectra(filename, start=None, end=None, save=True, dec=3):
+def bin_spectra(filename, start=None, end=None, save=True, dec=3, function=None):
     """
     Sums spectra from raw file and outputs to excel file
 
@@ -18,19 +18,23 @@ def bin_spectra(filename, start=None, end=None, save=True, dec=3):
     :param end: end scan (None will default to the last scan)
     :param save: whether to save into an excel document (if a string is provided, that filename will be used)
     :param dec: decimal places to track when binning the spectrum
+    :param function: mzml function number to sum (usually this is 1)
     :return: paired x, summed y lists
     """
 
     st = ScriptTime()
     st.printstart()
     mzml = mzML(filename)  # create mzML object
+    if function is None:
+        function = mzml.associate_to_function()
     if start is None:
-        start = mzml.functions[1]['sr'][0] + 1
+        start = mzml.functions[function]['sr'][0] + 1
     if end is None:
-        end = mzml.functions[1]['sr'][1] + 1
+        end = mzml.functions[function]['sr'][1] + 1
     x, y = mzml.sum_scans(
         start=start,
         end=end,
+        function=function,
         dec=dec,
     )
     if save is not False:
@@ -58,7 +62,7 @@ if __name__ == '__main__':
     #     endcan = None
     startscan=None
     endscan=None
-    fn = 'E:\\1Files\\Mass Spec Data\\LY-2016-08-02 08'
+    fn = 'C:\\Temp\\A2.new.MS2.1406.mzML.gz'
     bin_spectra(
         fn,  # raw filename to use
         start=startscan,  # start scan number


### PR DESCRIPTION
Fixed assumption that first mzML function number is `1`. 
- The default function is assigned as the minimum function number in the mzml. This may cause some problems in the future, but keyword passthrough should allow users to avoid those problems. 
- Several passthroughs have been added to allow user specification of `function`. 
- Any use of mzML functions has now been consistently labelled with the `function` keyword and variable

A couple of minor bug fixes and docstring updates as well. 